### PR TITLE
fix: resolve null members in nested teams query

### DIFF
--- a/github.graphql
+++ b/github.graphql
@@ -27,11 +27,6 @@ type Query {
       id
       name
       description
-      members {
-        login
-        id
-
-      }
       """
     )
 


### PR DESCRIPTION
`teams { members { ... } }`처럼 팀 안에서 멤버를 중첩 조회하면 멤버가 전부 null로 반환되는 버그를 고칩니다. 원인은 `Query.teams` 커넥터의 selection에 선언된 `members { login id }` 블록인데, GitHub의 팀 목록 API(`/orgs/DaleStudy/teams`) 응답에는 `members` 필드가 없어서 플래너가 이 필드들을 존재하지 않는 데이터에서 매핑하려다 non-null 위반으로 무너뜨립니다.